### PR TITLE
fix: improvements / fixes for existing codebase

### DIFF
--- a/baselines/corelation_cnn/create_dataset.py
+++ b/baselines/corelation_cnn/create_dataset.py
@@ -100,18 +100,33 @@ def get_video_embedding(video_id):
 
 
 def generate_corr_matrix(video_ids):
+    """Correlation matrix of the videos retrieved for a query.
+
+    Entry (i, j) correlates video i with video j across the 512 CLIP dimensions, so the
+    matrix describes how tight or how scattered the retrieved set is, which is the
+    signal the CNN reads. Correlating the transposed matrix instead relates the 512
+    dimensions to each other: that describes the CLIP embedding space rather than the
+    retrieved set, and estimates 512 variables from at most MAX_VIDEOS_PER_QUERY
+    observations.
+
+    The matrix is padded to a fixed MAX_VIDEOS_PER_QUERY square so that every sample
+    has the same shape and the DataLoader can batch them.
+    """
     embeddings = []
     for v_id in video_ids[:MAX_VIDEOS_PER_QUERY]:
         emb = get_video_embedding(v_id)
         if emb is not None:
             embeddings.append(emb)
 
+    padded = np.zeros((MAX_VIDEOS_PER_QUERY, MAX_VIDEOS_PER_QUERY), dtype=np.float32)
+
     if len(embeddings) < 2:
-        return np.zeros((512, 512), dtype=np.float32)
+        return padded
 
     matrix = np.vstack(embeddings)
-    corr = np.corrcoef(matrix.T)
-    return np.nan_to_num(corr).astype(np.float32)
+    corr = np.nan_to_num(np.corrcoef(matrix))
+    padded[: corr.shape[0], : corr.shape[1]] = corr
+    return padded
 
 
 def load_and_align(csv_path, jsonl_path, target_metric, limit=None):

--- a/baselines/corelation_cnn/create_dataset.py
+++ b/baselines/corelation_cnn/create_dataset.py
@@ -134,21 +134,35 @@ def load_and_align(csv_path, jsonl_path, target_metric, limit=None):
         return []
 
     df = pd.read_csv(csv_path)
-    preds_map = {}
+
+    # A caption can appear several times in the corpus, so every jsonl line is kept,
+    # grouped by query text and in file order. Storing a single list per text would let
+    # the last line win: all the rows sharing that caption would be paired with the same
+    # candidates, while keeping their own, different labels.
+    preds_map = collections.defaultdict(collections.deque)
     with open(jsonl_path, 'r') as f:
         for line in f:
             data = json.loads(line)
             query_text = [k for k in data.keys() if k != 'gt'][0]
-            preds_map[query_text] = data[query_text]
+            preds_map[query_text].append(data[query_text])
 
     aligned_data = []
+    rows_without_predictions = 0
     for _, row in df.iterrows():
         q = row['Query']
-        if q in preds_map:
-            aligned_data.append({'score': row[target_metric], 'video_ids': preds_map[q]})
+        candidates = preds_map.get(q)
+        if candidates:
+            # Each occurrence of the caption consumes its own line, so repeated captions
+            # keep receiving distinct candidate lists.
+            aligned_data.append({'score': row[target_metric], 'video_ids': candidates.popleft()})
+        else:
+            rows_without_predictions += 1
 
         if limit and len(aligned_data) >= limit:
             break
+
+    if rows_without_predictions:
+        print(f"{rows_without_predictions} rows of {csv_path} had no matching jsonl line.")
 
     return aligned_data
 

--- a/baselines/corelation_cnn/train_cnn.py
+++ b/baselines/corelation_cnn/train_cnn.py
@@ -116,7 +116,9 @@ predictions = []
 with torch.no_grad():
     for images, _ in test_loader:
         outputs = model(images.to(device))
-        predictions.extend(outputs.squeeze().tolist())
+        # A bare squeeze() turns a single-sample batch into a 0-d tensor, whose
+        # tolist() returns a float and makes extend() raise a TypeError.
+        predictions.extend(outputs.squeeze(-1).tolist())
 
 with open("/home/eduard/Desktop/Research/Adrian/VQPP/VAST/corelation_cnn_datasets/test_predictions.pickle", "wb") as f:
     pickle.dump(predictions, f)

--- a/baselines/finetune_clip/compute_correlations.py
+++ b/baselines/finetune_clip/compute_correlations.py
@@ -1,44 +1,73 @@
 import pickle
-import numpy as np
 import pandas as pd
 
 from scipy.stats import pearsonr, kendalltau
 
-with open("/home/eduard/Desktop/Research/Adrian/VQPP/VAST/clip_datasets/msrvtt_results.pickle", "rb") as f:
-    predictions = pickle.load(f)
-print(f"Length {len(predictions)}")
-df = pd.read_csv("/home/eduard/Desktop/Research/Adrian/VQPP/VAST/metrics/msrvtt_test.csv")
-rr = df["Reciprocal_Rank"].tolist()
-r10 = df["Recall@10"].tolist()
+PREDICTIONS_PATH = "/home/eduard/Desktop/Research/Adrian/VQPP/VAST/clip_datasets/msrvtt_results.pickle"
+TEST_DATASET_PATH = "/home/eduard/Desktop/Research/Adrian/VQPP/VAST/clip_datasets/msrvtt_clip_test.pickle"
+METRICS_CSV_PATH = "/home/eduard/Desktop/Research/Adrian/VQPP/VAST/metrics/msrvtt_test.csv"
 
-def split_into_groups(list, group_size):
-    return [list[i : i + group_size] for i in range(0, len(list), group_size)]
+# finetune_clip.py stores probabilities, so a candidate counts as predicted relevant
+# when its probability is at least 0.5.
+POSITIVE_THRESHOLD = 0.5
+
+
+def group_predictions_by_query(predictions, dataset):
+    """Groups the flat prediction list by the query index stored in the dataset.
+
+    The predictions are produced by a DataLoader built with shuffle=False, so element
+    i of the list corresponds to sample i of the dataset.
+    """
+    if not dataset:
+        raise ValueError(f"The dataset at {TEST_DATASET_PATH} is empty.")
+
+    if len(predictions) != len(dataset):
+        raise ValueError(
+            f"{len(predictions)} predictions for {len(dataset)} samples: the "
+            "predictions and the dataset do not come from the same run."
+        )
+
+    if len(dataset[0]) < 3:
+        raise ValueError(
+            "The dataset uses the old (features, label) format. Regenerate it with "
+            "create_dataset_clip.py so every sample carries its query index."
+        )
+
+    groups = {}
+    for prediction, sample in zip(predictions, dataset):
+        groups.setdefault(sample[2], []).append(prediction)
+    return groups
 
 
 def compute_metric_of_each_query(group):
+    """Predicted Recall@10 and Reciprocal Rank for a single query.
 
-    r10 = 0
+    group holds the predicted probability that each candidate is the ground-truth
+    video, in the order the retrieval system ranked the candidates.
+    """
+    # Recall@10: relevant candidates retrieved in the top 10, over the total number of
+    # relevant candidates. The relevant set is estimated by the candidates the model
+    # predicts as relevant. Slicing the group keeps this correct for queries with
+    # fewer than 10 candidates.
+    predicted_relevant = [score >= POSITIVE_THRESHOLD for score in group]
+    total_relevant = sum(predicted_relevant)
+    r10 = sum(predicted_relevant[:10]) / total_relevant if total_relevant else 0.0
 
-    for i in range(10):
-        if group[i] >= 0.5:
-            r10 += 1
-    r10 /= max(1, sum(1 for score in group if score >= 0.5))
-
-    mrr = 0
-
-    for i in range(len(group)):
-        if group[i] >= 0.5:
-            mrr = 1 / (i + 1)
+    # Reciprocal rank: the inverse of the rank of the first relevant candidate, 0 when
+    # no candidate is predicted relevant.
+    rr = 0.0
+    for rank, score in enumerate(group, start=1):
+        if score >= POSITIVE_THRESHOLD:
+            rr = 1.0 / rank
             break
 
-
-    return (r10, mrr)
+    return (r10, rr)
 
 
 def collect_metrics(all_metrics):
     r10s = [metric[0] for metric in all_metrics]
-    mrrs = [metric[1] for metric in all_metrics]
-    return r10s, mrrs
+    rrs = [metric[1] for metric in all_metrics]
+    return r10s, rrs
 
 
 def compute_correlations(map1, map2, title):
@@ -55,11 +84,26 @@ def compute_correlations(map1, map2, title):
     print()
 
 
-query_results = split_into_groups(predictions, 25)
-print(len(query_results))
-metrics = [compute_metric_of_each_query(group) for group in query_results]
+with open(PREDICTIONS_PATH, "rb") as f:
+    predictions = pickle.load(f)
+print(f"Length {len(predictions)}")
+
+with open(TEST_DATASET_PATH, "rb") as f:
+    test_dataset = pickle.load(f)
+
+df = pd.read_csv(METRICS_CSV_PATH)
+
+query_results = group_predictions_by_query(predictions, test_dataset)
+query_indices = sorted(query_results)
+print(f"{len(query_indices)} queries evaluated out of {len(df)} rows in the metrics CSV")
+
+metrics = [compute_metric_of_each_query(query_results[index]) for index in query_indices]
 predicted_r10, predicted_mrr = collect_metrics(metrics)
 
+# Compare only against the queries that actually produced predictions, otherwise the
+# ground truth would be shifted with respect to the predictions.
+r10 = df["Recall@10"].iloc[query_indices].tolist()
+rr = df["Reciprocal_Rank"].iloc[query_indices].tolist()
 
 compute_correlations(predicted_r10, r10, "  R10 Correlations")
 compute_correlations(predicted_mrr, rr, "RR Correlations")

--- a/baselines/finetune_clip/compute_correlations.py
+++ b/baselines/finetune_clip/compute_correlations.py
@@ -1,3 +1,4 @@
+import math
 import pickle
 import pandas as pd
 
@@ -10,6 +11,30 @@ METRICS_CSV_PATH = "/home/eduard/Desktop/Research/Adrian/VQPP/VAST/metrics/msrvt
 # finetune_clip.py stores probabilities, so a candidate counts as predicted relevant
 # when its probability is at least 0.5.
 POSITIVE_THRESHOLD = 0.5
+
+# Number of candidates per query assumed by datasets built before the query index was
+# stored with every sample.
+FALLBACK_GROUP_SIZE = 25
+
+
+def sigmoid(value):
+    if value >= 0:
+        return 1.0 / (1.0 + math.exp(-value))
+    exponential = math.exp(value)
+    return exponential / (1.0 + exponential)
+
+
+def as_probabilities(predictions):
+    """Converts predictions saved before finetune_clip.py applied the sigmoid itself.
+
+    Those runs stored raw logits, which would make POSITIVE_THRESHOLD mean a
+    probability of 0.62 instead of 0.5.
+    """
+    if all(0.0 <= prediction <= 1.0 for prediction in predictions):
+        return predictions
+
+    print("Predictions fall outside [0, 1], so they are logits: applying a sigmoid.")
+    return [sigmoid(prediction) for prediction in predictions]
 
 
 def group_predictions_by_query(predictions, dataset):
@@ -27,11 +52,18 @@ def group_predictions_by_query(predictions, dataset):
             "predictions and the dataset do not come from the same run."
         )
 
-    if len(dataset[0]) < 4:
-        raise ValueError(
-            "The dataset uses the old (features, label) format. Regenerate it with "
-            "create_dataset_clip.py so every sample carries its query index and text."
+    if len(dataset[0]) < 3:
+        # Datasets built before the query index was stored still load, using the old
+        # fixed-size grouping.
+        print(
+            f"The dataset carries no query index, falling back to groups of "
+            f"{FALLBACK_GROUP_SIZE}. Regenerate it with create_dataset_clip.py: a query "
+            "that yields fewer candidates shifts every query after it."
         )
+        return {
+            index: predictions[start : start + FALLBACK_GROUP_SIZE]
+            for index, start in enumerate(range(0, len(predictions), FALLBACK_GROUP_SIZE))
+        }
 
     groups = {}
     for prediction, sample in zip(predictions, dataset):
@@ -41,6 +73,10 @@ def group_predictions_by_query(predictions, dataset):
 
 def check_alignment(dataset, df):
     """Checks that a query index points at the CSV row of the same query."""
+    if len(dataset[0]) < 4 or "Query" not in df.columns:
+        print("No query text in the dataset or no Query column, skipping the check.")
+        return
+
     for sample in dataset:
         csv_query = str(df["Query"].iloc[sample[2]]).strip()
         if csv_query != str(sample[3]).strip():
@@ -98,6 +134,7 @@ def compute_correlations(map1, map2, title):
 with open(PREDICTIONS_PATH, "rb") as f:
     predictions = pickle.load(f)
 print(f"Length {len(predictions)}")
+predictions = as_probabilities(predictions)
 
 with open(TEST_DATASET_PATH, "rb") as f:
     test_dataset = pickle.load(f)

--- a/baselines/finetune_clip/compute_correlations.py
+++ b/baselines/finetune_clip/compute_correlations.py
@@ -27,16 +27,27 @@ def group_predictions_by_query(predictions, dataset):
             "predictions and the dataset do not come from the same run."
         )
 
-    if len(dataset[0]) < 3:
+    if len(dataset[0]) < 4:
         raise ValueError(
             "The dataset uses the old (features, label) format. Regenerate it with "
-            "create_dataset_clip.py so every sample carries its query index."
+            "create_dataset_clip.py so every sample carries its query index and text."
         )
 
     groups = {}
     for prediction, sample in zip(predictions, dataset):
         groups.setdefault(sample[2], []).append(prediction)
     return groups
+
+
+def check_alignment(dataset, df):
+    """Checks that a query index points at the CSV row of the same query."""
+    for sample in dataset:
+        csv_query = str(df["Query"].iloc[sample[2]]).strip()
+        if csv_query != str(sample[3]).strip():
+            raise ValueError(
+                f"Query {sample[2]} is '{sample[3]}' in the jsonl but '{csv_query}' in "
+                "the metrics CSV: the two files are not in the same order."
+            )
 
 
 def compute_metric_of_each_query(group):
@@ -93,6 +104,7 @@ with open(TEST_DATASET_PATH, "rb") as f:
 
 df = pd.read_csv(METRICS_CSV_PATH)
 
+check_alignment(test_dataset, df)
 query_results = group_predictions_by_query(predictions, test_dataset)
 query_indices = sorted(query_results)
 print(f"{len(query_indices)} queries evaluated out of {len(df)} rows in the metrics CSV")

--- a/baselines/finetune_clip/create_dataset_clip.py
+++ b/baselines/finetune_clip/create_dataset_clip.py
@@ -82,7 +82,7 @@ def load_video_frames(video_path, num_frames_to_sample, training=True):
     return torch.stack(frame_tensors).to(DEVICE)
 
 def process_lines(lines, text_model, tokenizer, vision_model, pbar_desc="Processing"):
-    """Builds (features, label, query_index) triplets.
+    """Builds (features, label, query_index, query_text) samples.
 
     query_index is the 0-based line number of the query in the jsonl file, which is
     assumed to follow the same order as the rows of the matching metrics CSV. It is
@@ -90,6 +90,9 @@ def process_lines(lines, text_model, tokenizer, vision_model, pbar_desc="Process
     candidates (missing videos are skipped, and a jsonl line may hold fewer than
     MAX_VIDEOS_PER_QUERY ids), so the evaluation cannot recover the grouping by
     slicing the flat prediction list into fixed-size chunks.
+
+    query_text lets the evaluation check that assumption against the Query column of
+    the CSV instead of trusting it.
     """
     dataset_pairs = []
     skipped_videos = 0
@@ -142,9 +145,10 @@ def process_lines(lines, text_model, tokenizer, vision_model, pbar_desc="Process
 
                 score = 1 if video_id == gt_id else 0
                 combined_features = np.hstack((text_emb, video_emb))
-                # Store the query this candidate belongs to, so the evaluation can
-                # group predictions per query instead of assuming fixed-size chunks.
-                dataset_pairs.append((combined_features, score, query_index))
+                # Store the query this candidate belongs to, so the evaluation can group
+                # predictions per query instead of assuming fixed-size chunks, and can
+                # check the query against the CSV row it is compared with.
+                dataset_pairs.append((combined_features, score, query_index, query_text))
 
     if skipped_videos:
         print(f"[{pbar_desc}] Skipped {skipped_videos} candidate videos that could not be loaded.")

--- a/baselines/finetune_clip/create_dataset_clip.py
+++ b/baselines/finetune_clip/create_dataset_clip.py
@@ -82,8 +82,19 @@ def load_video_frames(video_path, num_frames_to_sample, training=True):
     return torch.stack(frame_tensors).to(DEVICE)
 
 def process_lines(lines, text_model, tokenizer, vision_model, pbar_desc="Processing"):
+    """Builds (features, label, query_index) triplets.
+
+    query_index is the 0-based line number of the query in the jsonl file, which is
+    assumed to follow the same order as the rows of the matching metrics CSV. It is
+    stored explicitly because a query does not always contribute the same number of
+    candidates (missing videos are skipped, and a jsonl line may hold fewer than
+    MAX_VIDEOS_PER_QUERY ids), so the evaluation cannot recover the grouping by
+    slicing the flat prediction list into fixed-size chunks.
+    """
     dataset_pairs = []
-    for line in tqdm(lines, desc=pbar_desc):
+    skipped_videos = 0
+
+    for query_index, line in enumerate(tqdm(lines, desc=pbar_desc)):
         try:
             data = json.loads(line)
             gt_id = data.get('gt')
@@ -117,7 +128,9 @@ def process_lines(lines, text_model, tokenizer, vision_model, pbar_desc="Process
                         v_path = os.path.join(TEST_VIDEO_FOLDER, f"{video_id}{VIDEO_EXTENSION}")
                         frame_tensor = load_video_frames(v_path, NUM_FRAMES_TO_SAMPLE)
 
-                    if frame_tensor is None: continue
+                    if frame_tensor is None:
+                        skipped_videos += 1
+                        continue
 
                     visual_output = vision_model(frame_tensor)["image_embeds"]
                     visual_output = visual_output / visual_output.norm(dim=-1, keepdim=True)
@@ -129,7 +142,12 @@ def process_lines(lines, text_model, tokenizer, vision_model, pbar_desc="Process
 
                 score = 1 if video_id == gt_id else 0
                 combined_features = np.hstack((text_emb, video_emb))
-                dataset_pairs.append((combined_features, score))
+                # Store the query this candidate belongs to, so the evaluation can
+                # group predictions per query instead of assuming fixed-size chunks.
+                dataset_pairs.append((combined_features, score, query_index))
+
+    if skipped_videos:
+        print(f"[{pbar_desc}] Skipped {skipped_videos} candidate videos that could not be loaded.")
 
     return dataset_pairs
 

--- a/baselines/finetune_clip/create_dataset_clip4clip.py
+++ b/baselines/finetune_clip/create_dataset_clip4clip.py
@@ -77,7 +77,7 @@ def load_video_frames(video_path, num_frames_to_sample, training=True):
     return torch.stack(frame_tensors).to(DEVICE)
 
 def process_lines(lines, text_model, tokenizer, vision_model, pbar_desc="Processing"):
-    """Builds (features, label, query_index) triplets.
+    """Builds (features, label, query_index, query_text) samples.
 
     query_index is the 0-based line number of the query in the jsonl file, which is
     assumed to follow the same order as the rows of the matching metrics CSV. It is
@@ -85,6 +85,9 @@ def process_lines(lines, text_model, tokenizer, vision_model, pbar_desc="Process
     candidates (a jsonl line may hold fewer than MAX_VIDEOS_PER_QUERY ids), so the
     evaluation cannot recover the grouping by slicing the flat prediction list into
     fixed-size chunks.
+
+    query_text lets the evaluation check that assumption against the Query column of
+    the CSV instead of trusting it.
     """
     dataset_pairs = []
 
@@ -142,9 +145,10 @@ def process_lines(lines, text_model, tokenizer, vision_model, pbar_desc="Process
 
                 score = 1 if video_id == gt_id else 0
                 combined_features = np.hstack((text_emb, video_emb))
-                # Store the query this candidate belongs to, so the evaluation can
-                # group predictions per query instead of assuming fixed-size chunks.
-                dataset_pairs.append((combined_features, score, query_index))
+                # Store the query this candidate belongs to, so the evaluation can group
+                # predictions per query instead of assuming fixed-size chunks, and can
+                # check the query against the CSV row it is compared with.
+                dataset_pairs.append((combined_features, score, query_index, query_text))
 
     return dataset_pairs
 

--- a/baselines/finetune_clip/create_dataset_clip4clip.py
+++ b/baselines/finetune_clip/create_dataset_clip4clip.py
@@ -77,9 +77,18 @@ def load_video_frames(video_path, num_frames_to_sample, training=True):
     return torch.stack(frame_tensors).to(DEVICE)
 
 def process_lines(lines, text_model, tokenizer, vision_model, pbar_desc="Processing"):
+    """Builds (features, label, query_index) triplets.
+
+    query_index is the 0-based line number of the query in the jsonl file, which is
+    assumed to follow the same order as the rows of the matching metrics CSV. It is
+    stored explicitly because a query does not always contribute the same number of
+    candidates (a jsonl line may hold fewer than MAX_VIDEOS_PER_QUERY ids), so the
+    evaluation cannot recover the grouping by slicing the flat prediction list into
+    fixed-size chunks.
+    """
     dataset_pairs = []
 
-    for line in tqdm(lines, desc=pbar_desc):
+    for query_index, line in enumerate(tqdm(lines, desc=pbar_desc)):
         try:
             data = json.loads(line)
             gt_id = data.get('gt')
@@ -133,7 +142,9 @@ def process_lines(lines, text_model, tokenizer, vision_model, pbar_desc="Process
 
                 score = 1 if video_id == gt_id else 0
                 combined_features = np.hstack((text_emb, video_emb))
-                dataset_pairs.append((combined_features, score))
+                # Store the query this candidate belongs to, so the evaluation can
+                # group predictions per query instead of assuming fixed-size chunks.
+                dataset_pairs.append((combined_features, score, query_index))
 
     return dataset_pairs
 

--- a/baselines/finetune_clip/finetune_clip.py
+++ b/baselines/finetune_clip/finetune_clip.py
@@ -29,7 +29,9 @@ class CustomDataset(torch.utils.data.Dataset):
         self.dataset = dataset
 
     def __getitem__(self, index):
-        combined_features, individual_score = self.dataset[index]
+        # Samples are (features, label, query_index) triplets; the query index is only
+        # needed by the evaluation, so it is dropped here.
+        combined_features, individual_score = self.dataset[index][:2]
         return (
             torch.tensor(combined_features, dtype=torch.float).to(device),
             torch.tensor(individual_score, dtype=torch.float).to(device),

--- a/baselines/finetune_clip/finetune_clip.py
+++ b/baselines/finetune_clip/finetune_clip.py
@@ -134,5 +134,7 @@ with torch.no_grad():
     for combined_features, individual_score in test_loader:
         combined_features = combined_features.squeeze(1)
         pred = model(combined_features).squeeze(1)
-        test_predictions.extend(pred.tolist())
+        # The model is trained with BCEWithLogitsLoss, so it outputs logits. Store
+        # probabilities instead, because the evaluation thresholds these values.
+        test_predictions.extend(torch.sigmoid(pred).tolist())
 pickle.dump(test_predictions, open("/home/eduard/Desktop/Research/Adrian/VQPP/VAST/clip_datasets/msrvtt_results.pickle", "wb"))

--- a/baselines/llm/llm.py
+++ b/baselines/llm/llm.py
@@ -6,7 +6,7 @@ from google import genai
 from google.genai import types
 from sklearn.neighbors import NearestNeighbors
 from tqdm import tqdm
-import scipy
+import scipy.stats
 import json
 from groq import Groq
 from api_key import *
@@ -65,6 +65,14 @@ def get_embeddings_safe(text_list):
                     all_embeddings.extend([[0.0] * 768] * len(batch))
                     success = True
 
+        if not success:
+            # Without this the batch would contribute no embedding at all, and every
+            # later query would shift by one row. The neighbour indices are used as
+            # df_train.iloc[idx], so the prompt would then quote another query's recall.
+            print(f"\nBatch starting at index {i} failed after {retry_count} retries; "
+                  "using zero vectors to keep the embeddings aligned with the queries.")
+            all_embeddings.extend([[0.0] * 768] * len(batch))
+
     return np.array(all_embeddings)
 
 def predict_rank_with_groq(val_query, similar_examples):
@@ -106,7 +114,11 @@ def main():
     df_train = pd.read_csv('VAST\\vatex_train.csv')
     df_val = pd.read_csv('VAST\\vatex_test.csv')
 
-    scores = df_val["Recall@10"].tolist()
+    # Ground truth is collected next to the predictions, inside the loop. Taking the
+    # whole column up front would leave the two lists shifted as soon as a query is
+    # skipped, and calculate_correlations would then return a string instead of the
+    # four values the caller unpacks.
+    scores = []
 
     train_queries = df_train['Query'].astype(str).tolist()
     
@@ -159,7 +171,8 @@ def main():
             print(f"Query: {val_query} | Failed to get response")
         
         results.append(final_rank)
-        
+        scores.append(row["Recall@10"])
+
         time.sleep(4)
 
     pearson_corr, pvaluep, kendall_corr, pvalue = calculate_correlations(

--- a/baselines/meta_svr/get_metrics.py
+++ b/baselines/meta_svr/get_metrics.py
@@ -1,46 +1,123 @@
 import pickle
-import numpy as np
-import pandas as pd
 
-def split_into_groups(list, group_size):
-    return [list[i : i + group_size] for i in range(0, len(list), group_size)]
+# The CLIP classifier stores probabilities, so a candidate counts as predicted
+# relevant when its probability is at least 0.5. Keep this file in sync with
+# baselines/finetune_clip/compute_correlations.py, which computes the same metrics.
+POSITIVE_THRESHOLD = 0.5
+
+# Every split needs the predictions and the dataset they were produced from: the
+# dataset holds the query index of each candidate, which is what defines the groups.
+# meta_svr.py consumes all three splits, so all three are written here.
+SPLITS = {
+    "train": {
+        "predictions": r".\clip_results\VAST\msrvtt_train_predictions.pickle",
+        "dataset": r".\clip_datasets\VAST\msrvtt_clip_train.pickle",
+        "r10": r".\clip_results\VAST\msrvtt_train_r10.pickle",
+        "rr": r".\clip_results\VAST\msrvtt_train_rr.pickle",
+        "query_indices": r".\clip_results\VAST\msrvtt_train_query_indices.pickle",
+    },
+    "val": {
+        "predictions": r".\clip_results\VAST\msrvtt_val_predictions.pickle",
+        "dataset": r".\clip_datasets\VAST\msrvtt_clip_val.pickle",
+        "r10": r".\clip_results\VAST\msrvtt_val_r10.pickle",
+        "rr": r".\clip_results\VAST\msrvtt_val_rr.pickle",
+        "query_indices": r".\clip_results\VAST\msrvtt_val_query_indices.pickle",
+    },
+    "test": {
+        "predictions": r".\clip_results\VAST\msrvtt_test_predictions.pickle",
+        "dataset": r".\clip_datasets\VAST\msrvtt_clip_test.pickle",
+        "r10": r".\clip_results\VAST\msrvtt_test_r10.pickle",
+        "rr": r".\clip_results\VAST\msrvtt_test_rr.pickle",
+        "query_indices": r".\clip_results\VAST\msrvtt_test_query_indices.pickle",
+    },
+}
+
+
+def group_predictions_by_query(predictions, dataset, split):
+    """Groups the flat prediction list by the query index stored in the dataset.
+
+    The predictions are produced by a DataLoader built with shuffle=False, so element
+    i of the list corresponds to sample i of the dataset.
+    """
+    if not dataset:
+        raise ValueError(f"The {split} dataset is empty.")
+
+    if len(predictions) != len(dataset):
+        raise ValueError(
+            f"{split}: {len(predictions)} predictions for {len(dataset)} samples: the "
+            "predictions and the dataset do not come from the same run."
+        )
+
+    if len(dataset[0]) < 3:
+        raise ValueError(
+            f"The {split} dataset uses the old (features, label) format. Regenerate it "
+            "with create_dataset_clip.py so every sample carries its query index."
+        )
+
+    groups = {}
+    for prediction, sample in zip(predictions, dataset):
+        groups.setdefault(sample[2], []).append(prediction)
+    return groups
 
 
 def compute_metric_of_each_query(group):
+    """Predicted Recall@10 and Reciprocal Rank for a single query.
 
-    r10 = 0
+    group holds the predicted probability that each candidate is the ground-truth
+    video, in the order the retrieval system ranked the candidates.
+    """
+    # Recall@10: relevant candidates retrieved in the top 10, over the total number of
+    # relevant candidates. The relevant set is estimated by the candidates the model
+    # predicts as relevant. Slicing the group keeps this correct for queries with
+    # fewer than 10 candidates.
+    predicted_relevant = [score >= POSITIVE_THRESHOLD for score in group]
+    total_relevant = sum(predicted_relevant)
+    r10 = sum(predicted_relevant[:10]) / total_relevant if total_relevant else 0.0
 
-    for i in range(min(10, len(group))):
-        if group[i] >= 0.5:
-            r10 += 1
-    r10 /= max(1, sum(1 for score in group if score >= 0.5))
-
-    mrr = 0
-
-    for i in range(len(group)):
-        if group[i] >= 0.5:
-            mrr = 1 / (i + 1)
+    # Reciprocal rank: the inverse of the rank of the first relevant candidate, 0 when
+    # no candidate is predicted relevant.
+    rr = 0.0
+    for rank, score in enumerate(group, start=1):
+        if score >= POSITIVE_THRESHOLD:
+            rr = 1.0 / rank
             break
 
-
-    return (r10, mrr)
+    return (r10, rr)
 
 
 def collect_metrics(all_metrics):
     r10s = [metric[0] for metric in all_metrics]
-    mrrs = [metric[1] for metric in all_metrics]
-    return r10s, mrrs
+    rrs = [metric[1] for metric in all_metrics]
+    return r10s, rrs
 
-with open(r".\clip_results\VAST\msrvtt_test_predictions.pickle", "rb") as f:
-    predictions = pickle.load(f)
 
-query_results = split_into_groups(predictions, 25)
-print(len(query_results))
-metrics = [compute_metric_of_each_query(group) for group in query_results]
-predicted_r10, predicted_mrr = collect_metrics(metrics)
+def process_split(split, paths):
+    with open(paths["predictions"], "rb") as f:
+        predictions = pickle.load(f)
 
-with open(r".\clip_results\VAST\msrvtt_test_r10.pickle", "wb") as r10:
-    pickle.dump(predicted_r10, r10)
+    with open(paths["dataset"], "rb") as f:
+        dataset = pickle.load(f)
 
-with open(r".\clip_results\VAST\msrvtt_test_rr.pickle", "wb") as rr:
-    pickle.dump(predicted_mrr, rr)
+    query_results = group_predictions_by_query(predictions, dataset, split)
+    # The query indices are written next to the metrics so that meta_svr.py can line
+    # these values up with the BERT predictions instead of assuming both lists cover
+    # the same queries in the same order.
+    query_indices = sorted(query_results)
+    print(f"{split}: {len(query_indices)} queries")
+
+    metrics = [compute_metric_of_each_query(query_results[index]) for index in query_indices]
+    predicted_r10, predicted_rr = collect_metrics(metrics)
+
+    with open(paths["r10"], "wb") as f:
+        pickle.dump(predicted_r10, f)
+
+    with open(paths["rr"], "wb") as f:
+        pickle.dump(predicted_rr, f)
+
+    with open(paths["query_indices"], "wb") as f:
+        pickle.dump(query_indices, f)
+
+
+if __name__ == "__main__":
+    for split, paths in SPLITS.items():
+        process_split(split, paths)

--- a/baselines/meta_svr/get_metrics.py
+++ b/baselines/meta_svr/get_metrics.py
@@ -5,6 +5,10 @@ import pickle
 # baselines/finetune_clip/compute_correlations.py, which computes the same metrics.
 POSITIVE_THRESHOLD = 0.5
 
+# Number of candidates per query assumed by datasets built before the query index was
+# stored with every sample.
+FALLBACK_GROUP_SIZE = 25
+
 # Every split needs the predictions and the dataset they were produced from: the
 # dataset holds the query index of each candidate, which is what defines the groups.
 # meta_svr.py consumes all three splits, so all three are written here.
@@ -49,10 +53,17 @@ def group_predictions_by_query(predictions, dataset, split):
         )
 
     if len(dataset[0]) < 3:
-        raise ValueError(
-            f"The {split} dataset uses the old (features, label) format. Regenerate it "
-            "with create_dataset_clip.py so every sample carries its query index."
+        # Datasets built before the query index was stored still load, using the old
+        # fixed-size grouping.
+        print(
+            f"The {split} dataset carries no query index, falling back to groups of "
+            f"{FALLBACK_GROUP_SIZE}. Regenerate it with create_dataset_clip.py: a query "
+            "that yields fewer candidates shifts every query after it."
         )
+        return {
+            index: predictions[start : start + FALLBACK_GROUP_SIZE]
+            for index, start in enumerate(range(0, len(predictions), FALLBACK_GROUP_SIZE))
+        }
 
     groups = {}
     for prediction, sample in zip(predictions, dataset):

--- a/baselines/meta_svr/meta_svr.py
+++ b/baselines/meta_svr/meta_svr.py
@@ -21,9 +21,27 @@ bert_train = bert_train_df['Predicted_Score'].to_list()
 bert_val = bert_val_df['Predicted_Score'].to_list()
 bert_test = bert_test_df['Predicted_Score'].to_list()
 
-train = list(zip(bert_train, clip_train))
-val = list(zip(bert_val, clip_val))
-test = list(zip(bert_test, clip_test))
+def pair_estimators(bert_scores, clip_scores, split):
+    """Pairs the BERT score and the CLIP score of the same query.
+
+    The pairing is positional, so it is only correct when both lists cover the same
+    queries in the same order: the BERT scores come from the rows of the predictions
+    CSV, the CLIP scores from get_metrics.py. zip() stops at the shorter list without
+    reporting anything, which pairs scores belonging to different queries and only
+    surfaces later as an unrelated error, so the lengths are checked here instead.
+    """
+    if len(bert_scores) != len(clip_scores):
+        raise ValueError(
+            f"{split}: {len(bert_scores)} BERT scores and {len(clip_scores)} CLIP "
+            "scores. The two estimators must cover the same queries, in the same "
+            "order; regenerate them before training the meta model."
+        )
+    return list(zip(bert_scores, clip_scores))
+
+
+train = pair_estimators(bert_train, clip_train, "train")
+val = pair_estimators(bert_val, clip_val, "val")
+test = pair_estimators(bert_test, clip_test, "test")
 
 
 train_target = bert_train_df['Reciprocal_Rank'].to_list()

--- a/query_reformulation/finetune_phi4.py
+++ b/query_reformulation/finetune_phi4.py
@@ -63,6 +63,26 @@ def clean_generated_text(text):
 
     return text.strip()
 
+SYSTEM_MESSAGE = "Reformulate the user query to maximize retrieval. Output ONLY the reformulated query."
+
+# Training prompts carry this example, so generation has to use it too: a prompt built
+# without it is a format the policy was never trained on.
+ONE_SHOT_EXAMPLE = (
+    "<|user|>\nfunny cat videos<|end|>\n"
+    "<|assistant|>\ncompilation of funny cats playing<|end|>\n"
+)
+
+
+def build_prompt(query):
+    """The single prompt format, used for training, validation and test generation."""
+    return (
+        f"<|system|>\n{SYSTEM_MESSAGE}<|end|>\n"
+        f"{ONE_SHOT_EXAMPLE}"
+        f"<|user|>\n{query}<|end|>\n"
+        f"<|assistant|>\n"
+    )
+
+
 class BertRegressor(nn.Module):
     def __init__(self, n_outputs=1):
         super(BertRegressor, self).__init__()
@@ -119,11 +139,7 @@ class ValidationScoreCallback(TrainerCallback):
         self.val_df = pd.read_csv(val_csv_path)
         self.tokenizer = tokenizer
         self.judge = judge
-        self.prompts = []
-        sys_msg = "Reformulate the user query to maximize retrieval. Output ONLY the reformulated query."
-        for q in self.val_df['query']: 
-            txt = f"<|system|>\n{sys_msg}<|end|>\n<|user|>\n{q}<|end|>\n<|assistant|>\n"
-            self.prompts.append(txt)
+        self.prompts = [build_prompt(q) for q in self.val_df['query']]
 
     def on_step_end(self, args, state, control, model, **kwargs):
         if state.global_step % args.save_steps == 0 and state.global_step > 0:
@@ -162,11 +178,7 @@ class TestSetGenerationCallback(TrainerCallback):
         self.test_df = pd.read_csv(test_csv_path)
         self.tokenizer = tokenizer
         self.output_dir = output_dir
-        self.prompts = []
-        sys_msg = "Reformulate the user query to maximize retrieval. Output ONLY the reformulated query."
-        for q in self.test_df['Query']:
-            txt = f"<|system|>\n{sys_msg}<|end|>\n<|user|>\n{q}<|end|>\n<|assistant|>\n"
-            self.prompts.append(txt)
+        self.prompts = [build_prompt(q) for q in self.test_df['Query']]
 
     def on_save(self, args, state, control, model, **kwargs):
         step = state.global_step
@@ -234,20 +246,7 @@ def train():
     bert_judge = CustomBertJudge(reward_model, reward_tokenizer)
 
     def format_prompt(example):
-        sys_msg = "Reformulate the user query to maximize retrieval. Output ONLY the reformulated query."
-
-        one_shot = (
-            "<|user|>\nfunny cat videos<|end|>\n"
-            "<|assistant|>\ncompilation of funny cats playing<|end|>\n"
-        )
-        return {
-            "prompt": (
-                f"<|system|>\n{sys_msg}<|end|>\n"
-                f"{one_shot}"
-                f"<|user|>\n{example['query']}<|end|>\n"
-                f"<|assistant|>\n"
-            )
-        }
+        return {"prompt": build_prompt(example['query'])}
 
     ds_train = load_dataset("csv", data_files=TRAIN_FILE, split="train").map(format_prompt)
 

--- a/query_reformulation/finetune_phi4.py
+++ b/query_reformulation/finetune_phi4.py
@@ -95,19 +95,24 @@ class CustomBertJudge:
         return scores.flatten().cpu().tolist()
 
     def judge(self, prompts, completions, **kwargs):
+        """Returns the rank of the first completion of every pair.
+
+        OnlineDPOTrainer reads this as a rank, not as a probability: 0 means the first
+        completion wins, 1 means the second one does (it builds its chosen/rejected
+        mask with `rank == 0`). The higher reward therefore has to map to the lower
+        index, otherwise the completion with the worse QPP score is the one marked as
+        chosen and the policy is trained to lower it.
+        """
         flat_completions = [c for pair in completions for c in pair]
-        
+
         cleaned_queries = [clean_generated_text(str(c)) for c in flat_completions]
-        
+
         flat_scores = self.get_scores(cleaned_queries)
 
-        decision_probs = []
+        ranks = []
         for i in range(0, len(flat_scores), 2):
-            if flat_scores[i] > flat_scores[i+1]:
-                decision_probs.append(1.0)
-            else:
-                decision_probs.append(0.0)
-        return decision_probs
+            ranks.append(0 if flat_scores[i] >= flat_scores[i + 1] else 1)
+        return ranks
 
 class ValidationScoreCallback(TrainerCallback):
     def __init__(self, val_csv_path, tokenizer, judge):


### PR DESCRIPTION

# Probleme majore

## 1. Semnalul de preferinta din DPO era inversat

`query_reformulation/finetune_phi4.py:104-110`

`OnlineDPOTrainer` interpreteaza valoarea intoarsa de judge ca **rang**, nu ca probabilitate. Din sursa `trl`, identic de la v0.15.0 pana la v0.24.0:

```python
ranks_of_first_completion = self.judge.judge(
    prompts, list(zip(completions[:batch_size], completions[batch_size:]))
)
# convert ranks to a True/False mask:
# when rank == 0, it means the first completion is the best
# when rank == 1, it means the second completion is the best
mask = torch.tensor([rank == 0 for rank in ranks_of_first_completion], device=device)
```

Codul returna `1.0` exact cand prima completare avea scorul QPP mai bun, deci antrenamentul marca drept "chosen" completarea cu scorul mai mic. Politica era optimizata sa **scada** scorul QPP, adica exact invers fata de scop.

Nota: in `trl` recent suportul de `judge` a fost scos complet din OnlineDPO, deci versiunea ar trebui fixata in `pyproject.toml`.

---

## 2. Pragul de relevanta se aplica pe logits, nu pe probabilitati

`baselines/finetune_clip/finetune_clip.py:136`, `compute_correlations.py`, `baselines/meta_svr/get_metrics.py`

Modelul e antrenat cu `BCEWithLogitsLoss`, deci iesirea lui e logit, iar in pickle se salvau direct logit-ii. Evaluarea ii compara cu `0.5`, ceea ce inseamna de fapt o probabilitate de 0.62, nu 0.5. In plus `pos_weight` e in jur de 24 si impinge logit-ii in sus, deci pragul era arbitrar.

Afecteaza **fiecare query din fiecare rulare**, nu doar cazuri limita.

**Ce am schimbat:** se aplica `sigmoid` inainte de salvare, deci in pickle sunt probabilitati si `0.5` inseamna 0.5.

**Definitiile metricilor raman cele oficiale.** Recall@10 = relevante gasite in primii 10 impartit la totalul de relevante, RR = 1 / pozitia primului rezultat relevant. Singura corectie de formula e ca bucla mergea pe `range(10)` si dadea `IndexError` pentru query-urile cu mai putin de 10 candidati; acum se foloseste `group[:10]`.

---

## 3. Prompt diferit la antrenare fata de generare

`query_reformulation/finetune_phi4.py`

Prompturile de antrenare contineau un exemplu one-shot, iar cele din callback-ul de validare si din cel de generare pe test nu il conteneau. Politica era deci evaluata si pusa sa genereze intr-un format pe care nu l-a vazut la antrenare, deci si scorurile de validare si query-urile reformulate din CSV-ul final vin dintr-un format nefamiliar modelului.

**Ce am schimbat:** un singur `build_prompt`, folosit in toate trei locurile.

---

## 4. Matricea de corelatie se calcula pe dimensiuni, nu pe videoclipuri

`baselines/corelation_cnn/create_dataset.py:113`

`np.corrcoef` trateaza fiecare rand ca variabila si fiecare coloana ca observatie. Cu `matrix` de forma `(25, 512)`, transpusa insemna:

| | variabile | observatii | element (i, j) |
| --- | --- | --- | --- |
| vechi `corrcoef(matrix.T)` | cele 512 dimensiuni CLIP | cele 25 de videoclipuri | corelatia dintre dimensiunea i si dimensiunea j |
| nou `corrcoef(matrix)` | cele 25 de videoclipuri | cele 512 dimensiuni | corelatia dintre videoclipul i si videoclipul j |

Varianta veche raspundea la intrebarea "printre aceste 25 de videoclipuri, cand dimensiunea CLIP 3 e mare, e mare si dimensiunea 57?". Asta descrie spatiul de embedding CLIP, aproape identic pentru orice query, nu lista regasita. In plus estima 512 variabile din 25 de observatii, deci matricea avea rang cel mult 24 si mare parte din structura ei era artefact al numarului mic de observatii.

CNN-ul trebuie sa citeasca geometria listei regasite: rezultate stranse inseamna query usor, rezultate imprastiate inseamna query greu. Asta e o matrice video x video.

**Ce am schimbat:** `np.corrcoef(matrix)` fara transpusa, plus completare cu zerouri pana la 25x25 ca `DataLoader`-ul sa poata forma batch-uri cand un query are mai putin de 25 de videoclipuri incarcate. Intrarea CNN-ului devine `(B, 1, 25, 25)` in loc de `(B, 1, 512, 512)`, iar `Conv2d(1, 64, ...)` ramane valid.

Am pastrat un singur nivel de corelatie si un singur canal, cum e si acum in cod. Metoda originala descrie un lant cu doi pasi, matrice de similaritate si apoi corelatie pe ea, si combina channel-wise matricele mai multor extractoare de feature-uri. Aia ar fi o discutie despre fidelitatea metodei, nu un bug punctual, deci merita separat.

---

## 5. Captions duplicate pierdeau liniile din jsonl

`baselines/corelation_cnn/create_dataset.py:126-127`

`preds_map[query_text] = data[query_text]` pastra o singura lista de candidati per text de query, deci ultima linie din jsonl le suprascria pe precedentele. MSR-VTT are captions care se repeta, asa ca toate randurile cu acelasi text primeau candidatii ultimei linii, desi fiecare isi pastra propria eticheta, diferita. Practic o parte din dataset-ul Correlation CNN asocia matrici de corelatie cu scoruri care nu le apartin.

**Ce am schimbat:** pastram toate liniile, grupate pe text si in ordinea din fisier, iar fiecare rand consuma linia lui. Randurile ramase fara linie sunt numarate si raportate, in loc sa dispara tacut.

---

# Verificari si robustete

## 6. meta_svr: verificare de lungime in loc de taiere tacuta

`baselines/meta_svr/meta_svr.py`

Perechile (scor BERT, scor CLIP) se fac pe pozitie, iar `zip` se oprea tacut la lista mai scurta. Am adaugat o verificare explicita de lungime. Imperecherea ramane pozitionala: formatul CSV-urilor cu predictii BERT nu poate fi verificat din repo, fiindca niciun script de aici nu le produce cu coloanele `Predicted_Score` si `Reciprocal_Rank`.

## 7. Verificarea ordinii dintre jsonl si CSV

`baselines/finetune_clip/compute_correlations.py`

`query_index` e folosit ca index de rand in CSV-ul cu metrici, dar nimic din pipeline nu garanteaza ca cele doua fisiere sunt in aceeasi ordine. Se salveaza si textul query-ului si se compara cu coloana `Query` inainte de calcul.

## 8. Compatibilitate cu fisierele vechi

Pickle-urile fara `query_index` nu dau eroare, ci revin la gruparea pe 25 cu un avertisment. Predictiile salvate ca logits sunt trecute prin sigmoid la incarcare, ca pragul sa insemne acelasi lucru.

---

# Note minore

**Gruparea predictiilor CLIP pe pozitii fixe** (`create_dataset_clip.py`, `compute_correlations.py`). Asta e un detaliu minor insa e important in cazul in care a avut loc vreo problema de care nu stiam si cumva s-ar fi sarit peste queries. Extractorul scria o lista plata de perechi, iar evaluarea taia in bucati de 25, presupunand ca fiecare query contribuie cu exact 25 de candidati. Cand un video nu se poate incarca, `create_dataset_clip.py:120` face `continue` si grupul se scurteaza, dar numarul de grupuri ramane acelasi (`ceil(74/25) = 3` pentru 3 query-uri), deci nimic nu crapa si toate query-urile de dupa se decaleaza cu o pozitie. Perechile poarta acum `query_index` si gruparea se face dupa el. Se declanseaza doar cand lipsesc videoclipuri.

**Alinierea din baseline-ul LLM** (`baselines/llm/llm.py`). Ground truth-ul se lua ca intreaga coloana inainte de bucla, dar query-urile care nu se pot embedui sunt sarite cu `continue`, deci listele ieseau de lungimi diferite si dezpachetarea in patru valori crapa la final. Separat, un batch care epuiza cele 5 reincercari pe 429 nu adauga nimic in lista si decala indicii vecinilor. Ambele se declanseaza doar cand apar erori de API.

**`train_cnn.py:121`.** `squeeze()` sterge toate dimensiunile egale cu 1, deci un ultim batch cu un singur exemplu devine tensor 0-d, `tolist()` intoarce un float si `extend()` crapa cu `TypeError`. Latent: doar cand `len(test_dataset) % 32 == 1`.

---

## Ce trebuie rulat din nou

1. `create_dataset_clip.py` / `create_dataset_clip4clip.py` - dataset-urile trebuie regenerate ca sa contina `query_index`.
2. `finetune_clip.py` - ca predictiile sa fie salvate ca probabilitati.
3. `corelation_cnn/create_dataset.py` - matricele isi schimba forma si continutul.
4. `compute_correlations.py`, `get_metrics.py`, `meta_svr.py`, `train_cnn.py`.
5. `finetune_phi4.py` - antrenarea DPO, din cauza semnalului inversat.

## Ce nu e in acest PR

Raman pentru discutie separata: reward model-ul din reformulare antrenat pe VATEX/Reciprocal_Rank dar aplicat pe MSR-VTT/Recall@10, sampling-ul nedeterminist de cadre pentru val si test, `avg_word_length` din `linguistics.py` care isi suprascrie propria tokenizare, suprascrierea in loc a clipului in `download_vatex.py`, si caile hardcodate plus dependintele lipsa din `pyproject.toml`.
