### PR TITLE
Probleme de descarcare/incarcare a setului de date

### DIFF
--- a/prep_datasets/VATEX/download_vatex.py
+++ b/prep_datasets/VATEX/download_vatex.py
@@ -56,20 +56,33 @@ def split_audio_video(clip_path):
 
     filename = os.path.splitext(os.path.basename(clip_path))[0]
     audio_path = os.path.join(AUDIO_DIR, f"{filename}.mp3")
-    video_only_path = os.path.join(VIDEO_DIR, f"{filename}.mp4")
 
-    # Extract audio
-    subprocess.run([
+    audio = subprocess.run([
         "ffmpeg", "-i", clip_path, "-q:a", "0", "-map", "a", audio_path, "-y"
-    ], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+    ], capture_output=True, text=True)
 
-    # Extract video without audio
-    subprocess.run([
-        "ffmpeg", "-i", clip_path, "-c", "copy", "-an", video_only_path, "-y"
-    ], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+    if audio.returncode == 0:
+        print(f" -> Audio saved: {audio_path}")
+    else:
+        print(f" -> No audio extracted for {filename}")
 
-    print(f" -> Audio saved: {audio_path}")
-    print(f" -> Video (no audio) saved: {video_only_path}")
+    # The video without audio has to go through a temporary file. Writing it straight
+    # back to clip_path would hand ffmpeg the same path as input and output: the output
+    # is opened for writing, which truncates the clip while it is still being read, so
+    # the downloaded file ends up corrupted with nothing reported.
+    temp_video_path = f"{clip_path}.tmp.mp4"
+    video = subprocess.run([
+        "ffmpeg", "-i", clip_path, "-c", "copy", "-an", temp_video_path, "-y"
+    ], capture_output=True, text=True)
+
+    if video.returncode != 0:
+        print(f" -> Failed to strip the audio track of {filename}, keeping the original")
+        if os.path.exists(temp_video_path):
+            os.remove(temp_video_path)
+        return
+
+    os.replace(temp_video_path, clip_path)
+    print(f" -> Video (no audio) saved: {clip_path}")
 
 
 def main():

--- a/prep_datasets/VATEX/download_vatex.py
+++ b/prep_datasets/VATEX/download_vatex.py
@@ -3,6 +3,8 @@ import os
 import yt_dlp
 import subprocess
 
+from yt_dlp.utils import download_range_func
+
 ANNOTATION_FILE = "VATEX/vatex_training_v1.0.json"
 BASE_DIR = "VATEX/train"
 VIDEO_DIR = os.path.join(BASE_DIR, "videos")
@@ -25,7 +27,15 @@ def download_clip(entry):
     ydl_opts = {
         "format": "mp4[height<=480]",
         "outtmpl": clip_path,
-        "download_sections": {"*": [f"{int(start)}-{int(end)}"]},
+        # yt-dlp reads the requested sections from `download_ranges`, and expects a
+        # callable with the signature (info_dict, ydl). `download_sections` is the name
+        # of the command line flag, not of the API option, and unknown keys are ignored
+        # without any warning: the default is a single section with no start and no end,
+        # which downloads the whole video.
+        "download_ranges": download_range_func(None, [(int(start), int(end))]),
+        # Without this the cut lands on the nearest keyframe, which can be seconds away
+        # from the annotated segment.
+        "force_keyframes_at_cuts": True,
         "cookiesfrombrowser": ("firefox",),
         "quiet": True
     }


### PR DESCRIPTION

## Pe disc trebuie sa ajunga doar secventele anotate

Un `videoID` din VATEX are forma `{youtube_id}_{start}_{end}`, de exemplu `Ac6r3AhCLpo_000024_000034`, deci secundele 24-34. Descrierile anotate se refera **exclusiv** la acel interval de 10 secunde, iar elementul din corpus, cel care trebuie regasit, este segmentul, nu videoclipul intreg de pe YouTube.

Sunt doua cai de a ajunge acolo, si oricare rezolva problema:

- **Descarcam de la inceput doar secventele.** Asta face acest PR: corecteaza optiunea din `download_vatex.py`. Utila pentru descarcarile viitoare si pentru cine cloneaza repo-ul.
- **Extragem secventele din videoclipurile deja descarcate.** Fisierele intregi sunt deja pe disc, iar intervalul se reconstruieste din numele fisierului, deci se pot taia local cu ffmpeg, fara YouTube. Pentru corpusul actual e varianta mai buna: e mult mai rapida decat o redescarcare de zile si nu depinde de videoclipurile care intre timp au disparut de pe YouTube.

Ce nu e o optiune este sa lasam fisierele intregi si sa compensam la citire, pentru ca nimic din pipeline nu stie de interval, si nici nu ar avea cum: informatia exista doar in numele fisierului.

### De ce se descarcau integral

Scriptul parseaza corect intervalul, dar il transmite asa:

```python
"download_sections": {"*": [f"{int(start)}-{int(end)}"]},
```

`--download-sections` este **flag de linie de comanda**, iar in `yt_dlp/options.py` are `dest='download_ranges'`. Optiunea de API se numeste deci `download_ranges`, iar `download_sections` nu exista: apare de zero ori in intreaga biblioteca. `YoutubeDL` primeste `params` ca dictionar si citeste doar cheile pe care le cunoaste, fara sa valideze nimic, deci o cheie necunoscuta e ignorata in tacere.

Verificat empiric pe yt-dlp 2026.07.04, rulind chiar linia care decide intervalele (`self.params.get('download_ranges', lambda *_: [{}])(info_dict, self)`):

```
ydl_opts actual : ({},)                                    <- sectiune fara start si fara end = tot videoclipul
forma corecta   : ({'start_time': 24, 'end_time': 34},)
```

In plus `download_ranges` asteapta un **callable** cu semnatura `(info_dict, ydl)`, nu un dict, deci si tipul era gresit.

### Taierea nu se face nicaieri altundeva

| verificare | rezultat |
| --- | --- |
| parsarea `videoID` in start si end | doar in `download_vatex.py` |
| `-ss` / `-to` / `-t` la ffmpeg | zero aparitii; singurele apeluri ffmpeg sunt copiere de stream si extragere audio |
| `CAP_PROP_POS_MSEC` sau `CAP_PROP_FPS` | zero, se citeste doar `CAP_PROP_FRAME_COUNT` |
| indicii de cadre | toate trei extractoarele merg de la 0 la `total_frames - 1` |
| `decord`, `ffmpeg-python` | declarate in `pyproject.toml`, niciodata importate |
| versiunea stearsa `finetune_clip/create_dataset.py` | aceeasi esantionare pe `total_frames`, zero taiere temporala |

**Ce am schimbat:** `download_ranges` cu `download_range_func`, plus `force_keyframes_at_cuts` ca taietura sa fie exacta; fara el se cade pe cel mai apropiat keyframe, care poate fi la cateva secunde distanta.

---

## 2. ffmpeg suprascria clipul cu el insusi

`split_audio_video` calcula `video_only_path` ca `VIDEO_DIR/{filename}.mp4`, adica exact `clip_path`, si il dadea lui ffmpeg si ca intrare si ca iesire. Fisierul de iesire se deschide pentru scriere, deci sursa era trunchiata in timp ce inca era citita. `stdout` si `stderr` mergeau in `DEVNULL`, iar codul de retur nu se verifica, deci coruperea era complet invizibila.

**Ce am schimbat:** se scrie intr-un fisier temporar si se inlocuieste cu `os.replace` abia dupa ce ffmpeg termina cu succes, la fel ca in scriptul de MSR-VTT. Esecurile se raporteaza.

---

## Ce inseamna asta pentru rezultate

Extractoarele iau 12 cadre distribuite pe toata durata fisierului si le mediaza intr-un singur vector, deci reprezentarea descrie tot fisierul, nu segmentul anotat. Fractia asteptata de cadre care cad in intervalul anotat este `durata_clipului / durata_videoclipului`: pentru un videoclip sursa de 5 minute si un clip de 10 secunde, in medie **0.4 cadre din 12**, deci de obicei niciunul nu arata ce descrie captionul.

De verificat inainte de orice discutie despre cifre: daca rularile GRAM si VAST au folosit aceste fisiere, atunci nu doar feature-urile CLIP sunt afectate, ci si metricile din CSV-uri, care sunt etichetele intregului benchmark QPP.

---

## Alte probleme de incarcare, ramase de discutat

Nu sunt in acest PR, pentru ca au nevoie de o decizie inainte de a fi schimbate.

**Esantionarea e nedeterminista pentru val si test.** `load_video_frames(..., training=True)` are default-ul `True` si nu e suprascris la niciun apel, deci cadrele se aleg cu `np.random.randint`, fara seed, si pentru val si pentru test. Ramura determinista exista dar e cod mort. Feature-urile difera de la o rulare la alta, deci cifrele nu se reproduc exact.

**Trei politici diferite de esantionare pentru acelasi corpus.** `create_dataset_clip.py` face segmente cu alegere aleatoare plus retry la cadrul 0; `create_dataset_clip4clip.py` la fel dar cu `randint(start, end + 1)` si fara retry; `corelation_cnn/create_dataset.py` face `np.linspace` uniform. Aceleasi videoclipuri sunt reprezentate diferit in functie de baseline.

**Fallback-urile la cadre nereusite difera si sunt tacute.** Unul insereaza un cadru de zerouri printre cadre reale, altul inlocuieste tot videoclipul cu zerouri si il pune in cache sub id-ul lui, al treilea returneaza mai putine cadre. Toate intra in dataset ca embedding-uri valide.

**`cap.set(CAP_PROP_POS_FRAMES, idx)` nu garanteaza cadrul cerut.** OpenCV sare la cel mai apropiat keyframe, iar pentru videoclipuri YouTube cu frame rate variabil si `CAP_PROP_FRAME_COUNT` estimat, indicele cerut si cadrul citit pot sa nu coincida. Citirea secventiala sau `decord`, care oricum e deja in dependinte, ar fi mai sigure.
